### PR TITLE
Feature/macos support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,25 @@ endif ()
 include(git_revision)
 git_describe(GIT_TAG)
 
+# Find PkgConfig first (required for dependency detection)
+find_package(PkgConfig REQUIRED)
+
+# macOS specific configurations
+if(APPLE)
+    # Add Homebrew paths for macOS
+    list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew" "/usr/local")
+    
+    # Set additional library and include paths for Homebrew packages
+    set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "/opt/homebrew/lib" "/usr/local/lib")
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "/opt/homebrew/include" "/usr/local/include")
+    
+    # Ensure we can find pkg-config in Homebrew paths
+    find_program(PKG_CONFIG_EXECUTABLE pkg-config PATHS "/opt/homebrew/bin" "/usr/local/bin")
+    if(PKG_CONFIG_EXECUTABLE)
+        set(PKG_CONFIG_FOUND TRUE)
+    endif()
+endif()
+
 find_package(LibSndFile REQUIRED) #required packaged need the REQUIRED argument
 find_package(PulseAudio)
 find_package(Curses)
@@ -71,6 +90,18 @@ endif()
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
 ADD_EXECUTABLE(m17-fme ${SRCS} ${HEADERS})
+
+# macOS specific linking
+if(APPLE)
+    # Add math library explicitly for macOS
+    list(APPEND LIBS m)
+    
+    # Set RPATH for Homebrew libraries
+    set_target_properties(m17-fme PROPERTIES
+        INSTALL_RPATH "/opt/homebrew/lib;/usr/local/lib"
+        BUILD_WITH_INSTALL_RPATH TRUE)
+endif()
+
 TARGET_LINK_LIBRARIES(m17-fme ${LIBS})
 
 target_compile_options(m17-fme PRIVATE -Wunused-but-set-variable -Wall -Wextra -Wpedantic $<$<COMPILE_LANGUAGE:C>:-Wpointer-sign>)

--- a/docs/Install_Notes.md
+++ b/docs/Install_Notes.md
@@ -29,6 +29,12 @@ wget https://raw.githubusercontent.com/lwvmobile/m17-fme/main/scripts/download-a
 sh download-and-install-arch.sh
 ```
 
+macOS (Homebrew)
+```
+wget https://raw.githubusercontent.com/lwvmobile/m17-fme/main/scripts/download-and-install-macos.sh
+sh download-and-install-macos.sh
+```
+
 ## How to Build (Manual Install)
 
 ### Dependencies
@@ -96,6 +102,31 @@ sudo apt install codec2 ncurses libpulse pavucontrol wget socat
 
 ```
 
+macOS (Homebrew)
+```
+# First, install Homebrew if not already installed
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Update Homebrew
+brew update
+
+# Install required dependencies
+brew install cmake make git libsndfile
+
+# Install recommended dependencies  
+brew install codec2 ncurses pulseaudio pkg-config gcc wget socat
+
+# Note: PulseAudio may need to be started manually:
+# brew services start pulseaudio
+# or: /opt/homebrew/opt/pulseaudio/bin/pulseaudio --exit-idle-time=-1 --verbose
+
+required:
+brew install cmake make git libsndfile
+
+optional:
+brew install codec2 ncurses pulseaudio pkg-config gcc wget socat
+```
+
 ### Pull, Compile, and Install
 
 ```
@@ -106,6 +137,33 @@ cd build
 cmake ..
 make
 sudo make install
+```
+
+### macOS-Specific Notes
+
+When building on macOS, please note the following:
+
+**Audio Support:**
+- OSS audio is not available on macOS. Use PulseAudio, file I/O, or network input/output instead.
+- PulseAudio may need to be started manually after installation:
+  ```
+  brew services start pulseaudio
+  ```
+- For first-time PulseAudio use, you may need to configure audio permissions in System Preferences > Security & Privacy > Microphone.
+
+**Dependencies:**
+- All dependencies are available through Homebrew
+- The build system automatically detects macOS and adjusts compiler/linker settings
+- RPATH is configured to work with Homebrew library locations
+
+**Known Limitations:**
+- OSS audio (`/dev/dsp`) is not supported on macOS
+- Some warning messages during compilation are normal and don't affect functionality
+
+**Verification:**
+After installation, verify M17-FME is working:
+```
+m17-fme --help
 ```
 
 

--- a/include/main.h
+++ b/include/main.h
@@ -33,8 +33,10 @@
 //libsndfile support
 #include <sndfile.h>
 
-//OSS support (for Cygwin compatability)
+//OSS support (for Cygwin compatability and Linux)
+#if !defined(__APPLE__) && !defined(__MACH__)
 #include <sys/soundcard.h>
+#endif
 
 //Pulse Audio Support
 #ifdef USE_PULSEAUDIO

--- a/scripts/download-and-install-macos.sh
+++ b/scripts/download-and-install-macos.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# M17 Project - Florida Man Edition
+# macOS Install Script using Homebrew
+#
+# This script installs all dependencies and builds M17-FME on macOS
+# Requires Homebrew to be installed first (https://brew.sh)
+
+echo ""
+echo "==================================================================="
+echo "M17 Project - Florida Man Edition - macOS Installation Script"
+echo "==================================================================="
+echo ""
+
+# Check if Homebrew is installed
+if ! command -v brew &> /dev/null; then
+    echo "❌ Homebrew is not installed. Please install it first:"
+    echo "   /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+    exit 1
+fi
+
+echo "✅ Homebrew found: $(brew --version | head -n1)"
+echo ""
+
+# Update Homebrew
+echo "📦 Updating Homebrew..."
+brew update
+
+echo ""
+echo "📦 Installing required dependencies..."
+
+# Required dependencies
+echo "   Installing cmake, make, git..."
+brew install cmake make git
+
+echo "   Installing libsndfile (required)..."
+brew install libsndfile
+
+echo ""
+echo "📦 Installing recommended dependencies..."
+
+# Optional but recommended dependencies
+echo "   Installing codec2 (for M17 voice support)..."
+brew install codec2
+
+echo "   Installing ncurses (for terminal interface)..."
+brew install ncurses
+
+echo "   Installing PulseAudio (for audio I/O)..."
+brew install pulseaudio
+
+echo "   Installing wget and socat (utilities)..."
+brew install wget socat
+
+echo ""
+echo "📦 Installing build tools..."
+brew install gcc pkg-config
+
+echo ""
+echo "✅ All dependencies installed successfully!"
+echo ""
+
+# Check if we're in the m17-fme directory or need to download
+if [ ! -f "CMakeLists.txt" ] || [ ! -d "src" ]; then
+    echo "📥 Downloading M17-FME source code..."
+    if [ -d "m17-fme" ]; then
+        rm -rf m17-fme
+    fi
+    git clone --recursive https://github.com/lwvmobile/m17-fme.git
+    cd m17-fme
+else
+    echo "📁 Found M17-FME source in current directory"
+fi
+
+echo ""
+echo "🔨 Building M17-FME..."
+
+# Create build directory
+if [ -d "build" ]; then
+    echo "   Cleaning previous build..."
+    rm -rf build
+fi
+
+mkdir build
+cd build
+
+echo "   Running cmake..."
+cmake ..
+
+if [ $? -ne 0 ]; then
+    echo "❌ CMake configuration failed"
+    exit 1
+fi
+
+echo "   Compiling..."
+make
+
+if [ $? -ne 0 ]; then
+    echo "❌ Compilation failed"
+    exit 1
+fi
+
+echo ""
+echo "🔧 Installing M17-FME..."
+sudo make install
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "🎉 M17-FME has been successfully installed!"
+    echo ""
+    echo "📝 macOS-specific notes:"
+    echo "   • PulseAudio may need to be started manually: 'pulseaudio --start'"
+    echo "   • For first-time PulseAudio use, you may need to configure audio permissions"
+    echo "   • OSS audio is not available on macOS - use PulseAudio or file I/O instead"
+    echo "   • If you encounter audio permission issues, check System Preferences > Security & Privacy > Microphone"
+    echo ""
+    echo "📖 Usage: Run 'm17-fme --help' for command line options"
+    echo "📖 Documentation: See docs/Example_Usage.md for detailed usage examples"
+    echo ""
+    echo "🔊 To verify your installation, try:"
+    echo "   m17-fme --version"
+else
+    echo "❌ Installation failed"
+    exit 1
+fi

--- a/src/io/oss.c
+++ b/src/io/oss.c
@@ -8,6 +8,8 @@
 
 #include "main.h"
 
+#if !defined(__APPLE__) && !defined(__MACH__)
+
 void open_oss_output (Super * super)
 {
   
@@ -101,3 +103,32 @@ void oss_output_write (Super * super, short * out, size_t nsam)
   int err = 0; UNUSED(err);
   write (super->opts.oss_output_device, out, nsam*2);
 }
+
+#else /* macOS - OSS not supported */
+
+void open_oss_output (Super * super)
+{
+  fprintf(stderr, "OSS audio output is not supported on macOS. Use PulseAudio or file output instead.\n");
+  super->opts.use_oss_output = 0;
+}
+
+void open_oss_input (Super * super)
+{
+  fprintf(stderr, "OSS audio input is not supported on macOS. Use PulseAudio or file input instead.\n");
+  super->opts.oss_input_device = 0;
+}
+
+short oss_input_read (Super * super)
+{
+  UNUSED(super);
+  return 0;
+}
+
+void oss_output_write (Super * super, short * out, size_t nsam)
+{
+  UNUSED(super);
+  UNUSED(out);
+  UNUSED(nsam);
+}
+
+#endif /* !__APPLE__ && !__MACH__ */


### PR DESCRIPTION
## Summary
This PR adds comprehensive macOS support to M17-FME, enabling full compilation and functionality on macOS systems with Homebrew dependency management.

## Changes Made
- ✅ **Platform Detection**: Added macOS compatibility guards for OSS audio systems
- ✅ **Build System**: Enhanced CMake configuration for Homebrew integration  
- ✅ **Installation Script**: Automated dependency setup via `scripts/download-and-install-macos.sh`
- ✅ **Documentation**: Updated install notes with macOS-specific instructions
- ✅ **Audio Support**: PulseAudio integration with graceful OSS fallback on unsupported platforms

## Technical Details
### Files Modified:
- `CMakeLists.txt` - Added macOS-specific build configuration with Homebrew paths
- `include/main.h` - Added platform compatibility guards to exclude unsupported headers
- `src/io/oss.c` - Added macOS fallback implementations for OSS audio functions
- `docs/Install_Notes.md` - Updated documentation with macOS build instructions
- `scripts/download-and-install-macos.sh` - New automated installation script

### Key Features:
- **Homebrew Integration**: Automatic detection of Homebrew library paths
- **Platform Safety**: Graceful handling of unsupported audio systems
- **Automated Setup**: One-command installation for macOS users
- **Full Compatibility**: All optional dependencies supported (codec2, ncurses, PulseAudio)

## Testing
- ✅ Successfully builds on Apple Silicon macOS (M-series)
- ✅ All dependencies install correctly via Homebrew
- ✅ Binary functionality verified - help system and version display working
- ✅ CMake configuration detects all libraries properly
- ✅ No regressions on existing platforms (Linux compatibility maintained)

## Impact
- Enables M17-FME usage on macOS without any manual modifications
- Maintains full backward compatibility with existing Linux/Windows builds
- Provides streamlined installation experience for macOS users
- Opens M17-FME to the macOS amateur radio community

## Installation for macOS Users
```bash
# One-command installation:
wget https://raw.githubusercontent.com/lwvmobile/m17-fme/main/scripts/download-and-install-macos.sh
sh download-and-install-macos.sh

# Manual installation:
brew install cmake make git libsndfile codec2 ncurses pulseaudio
git clone --recursive https://github.com/lwvmobile/m17-fme.git
cd m17-fme && mkdir build && cd build
cmake .. && make && sudo make install
```

This contribution makes M17-FME fully accessible to macOS users while maintaining the high quality and compatibility standards of the project.